### PR TITLE
[PR] Feat lib clips

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1,16 +1,58 @@
-""" cv-tbox Split Creator - Configuration File """
+""" cv-tbox Split Maker - Configuration File """
 
 import os
+import sys
+import platform
 
+is_windows: bool = os.name == "nt"
+is_linux: bool = sys.platform == "Linux"
+is_wsl: bool = "WSL" in platform.uname().release
+
+# Drive prefixes - to support running on different systems
+
+# DRV_COMPRESSED: downloaded compressed datasets (e.g. slow backup drive)
+# DRV_MEDIA: used to expand clips in hierarchical structure (e.g. large HDD drive)
+# DRV_WORK: Your actual work area for hierarchical clips (e.g. speedy SSD drive)
+# DRV_METADATA: Your actual work area for metadata (e.g. speedy SSD drive)
+if is_windows:
+    DRV_COMPRESSED: str = "V:\\"    # downloaded compressed datasets (e.g. slow backup drive)
+    DRV_MEDIA: str = "M:\\"         # used to expand clips in hierarchical structure
+    DRV_WORK: str = "T:\\"
+    DRV_METADATA: str = "T:\\"
+elif is_wsl:
+    DRV_COMPRESSED: str = "/mnt/v"
+    DRV_MEDIA: str = "/mnt/m"
+    DRV_WORK: str = "/mnt/t"
+    DRV_METADATA: str = "/mnt/t"
+elif is_linux:
+    DRV_COMPRESSED: str = "/mnt/v"
+    DRV_MEDIA: str = "/mnt/m"
+    DRV_WORK: str = "/mnt/t"
+    DRV_METADATA: str = "/mnt/t"
+else:
+    print("FATAL: Unsupported system!")
+    sys.exit(-1)
 
 # Locations
 
-CV_COMPRESSED_BASE_DIR: str = os.path.join("V:", os.sep, "DATASETS", "VOICE", "CV")
-CV_DATASET_BASE_DIR: str = os.path.join("M:", os.sep, "DATASETS", "CV")
+CV_COMPRESSED_BASE_DIR: str = os.path.join(DRV_COMPRESSED, "DATASETS", "VOICE", "cv")
+
+CV_DS_MEDIA_DIR: str = os.path.join(DRV_MEDIA, "DATASETS", "cv")
+CV_DS_WORK_DIR: str = os.path.join(DRV_WORK, "DATASETS", "cv")
+CV_DS_ALL_CLIPS_DIR: str = os.path.join(CV_DS_MEDIA_DIR, "clips")
+
+CV_DS_METADATA_DIR: str = os.path.join(DRV_METADATA, "METADATA", "cv")
+
 
 # Latest Version to work on
 
 CV_DATASET_VERSION: str = "cv-corpus-17.0-2024-03-15"
+
+# Language Codes we fully work on
+# These datasets will fully be expanded regardless of --all setting
+# Into the DRV_WORK drive - in addition to DRV_MEDIA
+
+CV_FULL_LC_LIST: list[str] = ["tr"]
 
 # Splitting Parameters
 

--- a/languages.py
+++ b/languages.py
@@ -127,7 +127,10 @@ CV_LANGUAGES: list[str] = [
     "zza",
 ]
 
+# Updated on April 2024 from https://github.com/openai/whisper/blob/main/whisper/tokenizer.py
 WHISPER_LANGUAGES: list[str] = [
+    "af",
+    "am",
     "ar",
     "as",
     "az",
@@ -135,9 +138,11 @@ WHISPER_LANGUAGES: list[str] = [
     "be",
     "bg",
     "bn",
+    "bo",
     "br",
+    "bs",
     "ca",
-    "cv",
+    "cs",
     "cy",
     "da",
     "de",
@@ -148,53 +153,82 @@ WHISPER_LANGUAGES: list[str] = [
     "eu",
     "fa",
     "fi",
+    "fo",
     "fr",
     "gl",
+    "gu-IN", # gujarati "gu" in Whisper
     "ha",
+    "haw", # Hawaiian - NOT IN CV
+    "he",
     "hi",
+    "hr",
+    "ht",
     "hu",
-    "hy-AM",
+    "hy-AM", # armenian "hy" in Whisper
     "id",
     "is",
     "it",
     "ja",
+    "jv", # javanese "jw" in Whisper
     "ka",
     "kk",
+    "km",
+    "kn",
     "ko",
+    "la", # latin - NOT IN CV
+    "lb",
+    "ln",
     "lo",
     "lt",
     "lv",
+    "mg",
+    "mi", # maori - NOT IN CV
     "mk",
     "ml",
     "mn",
     "mr",
+    "ms",
     "mt",
-    "ne-NP",
+    "my", # Myanmar - Burmese in CV
+    "ne-NP", # nepali "ne" in Whisper
     "nl",
-    "nn-NO",
+    "nn-NO", # nynorsk "nn" in Whisper
+    "no", # norwegian => nb-NO ? (Norwegian Bokmål) in CV? (not yet released)
     "oc",
-    "pa-IN",
+    "pa-IN", # punjabi "pa" in Whisper
     "pl",
+    "ps",
     "pt",
     "ro",
     "ru",
+    "sa", # sanskrit - NOT IN CV
+    "sd",
+    "si",
     "sk",
     "sl",
+    "sn", # shona - NOT IN CV
+    "so",
+    "sq",
     "sr",
-    "sv-SE",
+    "su", # sundanese - NOT IN CV
+    "sv-SE", # swedish "sv" in Whisper
     "sw",
     "ta",
+    "te",
+    "tg",
     "th",
     "tk",
+    "tl",
     "tr",
     "tt",
     "uk",
     "ur",
     "uz",
     "vi",
+    "yi",
     "yo",
     "yue",
-    "zh-CN",
+    "zh-CN", # chinese "zh" in Whisper
 ]
 
 FLEURS_LANGUAGES: list[str] = [
@@ -287,3 +321,38 @@ VOXPOPULI_LANGUAGES: list[str] = [
 
 # LANGUAGES WITH EXTERNAL TEST SET
 LANGUAGES_ALLOWED: list[str] = sorted(list(set(VOXPOPULI_LANGUAGES + FLEURS_LANGUAGES)))
+
+#
+# CV - WHISPER language codes: Unmatched ones
+#
+# 'bo', # Tibetan - IN PROGRESS
+# 'bs', # Bosnian - IN PROGRESS
+# 'fo', # faroese - IN PROGRESS
+# 'gu', # gujarati => gu-IN - IN PROGRESS
+# 'haw', # hawaiian - NOT IN CV
+# 'hr', # croatian - IN PROGRESS
+# 'hy', # armenian => hy-AM
+# 'jw', # javanese => jv
+# 'km', # Khmer - IN PROGRESS
+# 'kn', # kannada - IN PROGRESS
+# 'la', # latin - NOT IN CV
+# 'lb', # luxembourgish - IN PROGRESS
+# 'ln', # lingala - IN PROGRESS
+# 'mg', # malagasy - IN PROGRESS
+# 'mi', # maori - NOT IN CV
+# 'ms', # malay - IN PROGRESS
+# 'my', # Myanmar - Burmese in CV
+# 'ne', # nepali => ne-NP
+# 'nn', # nynorsk => nn-NO (Norwegian Nynorsk)
+# 'no', # norwegian => nb-NO (Norwegian Bokmål ???)
+# 'pa', # punjabi => pa-IN
+# 'sa', # sanskrit - NOT IN CV
+# 'sd', # sindhi - IN PROGRESS
+# 'si', # sinhala - IN PROGRESS
+# 'sn', # shona - NOT IN CV
+# 'so', # somali - IN PROGRESS
+# 'su', # sundanese - NOT IN CV
+# 'sv', # swedish => sv-SE
+# 'tg', # tajik - IN PROGRESS
+# 'tl', # tagalog - IN PROGRESS
+# 'zh' # chinese => zh-CN


### PR DESCRIPTION
Rework on `extract.py` and add "middleware" to expand clips into an hierarchical structure to overcome OS bottlenecks from hundreds of thousands of clips in a directory.

- Repo is renamed to cv-tbox-split-maker
- We can now extract metadata and clips on different drives (compression, speed etc)
- Add cv_extractor module/library to handle the hierarchical structure
- Rewrite extract.py with cv_extractor's methods
