### PR TITLE
[PR] Release: Move data and add delta-upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-setuptools
-pandas
-pyarrow
-psutil
-tqdm
-av
+# Use Python v3.12.x or greater
+setuptools>=75.1.0
+pandas>=2.2.3
+pyarrow>=17.0.0
+psutil>=6.0.0
+tqdm>=4.66.5
+av>=13.0.0
 git+https://github.com/ftyers/commonvoice-utils.git@main
 git+https://github.com/common-voice/CorporaCreator.git@master


### PR DESCRIPTION
This PR includes (WIP):
- [x] Add versions in requirements.txt
- [ ] Moving the data out of the code directory. As we work with all languages and all algorithms, these directories became huge (multiple hundreds of GBs) which we would like to keep on a spinning drive and use Windows "compact" on them to speed up retrieval and save some space (they compress into like 10-15% of the original).
  - [x] The `<repodir>/data` dir will stay here as it is part of the code
  - [ ] `experiments` and `results` will move to another place pointed by the `conf.py` file
- [ ] Add a `delta_upgrade.py` script. If you have e.g. full v.18.0 dataset file(s), you can use v19.0 delta releases (usually much more smaller then the full version) to create full v19.0 files. But this need the following steps:
  - [ ] Expand full v18.0 metadata, expand delta v19.0 metadata
  - [ ] Merge v19.0 validated & invalidated files and save into full v19.0.
  - [ ] Here "other" needs special attention, because some of the records might be moved into new validated or invalidated between versions, and new records might be added.
  - [ ] Use Corpora Creator "s1" algorithm to create default splits
